### PR TITLE
fix C compilation warnings on Linux

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -479,12 +479,12 @@ const u64 U64_PER_MB = 0x20000;
 const u64 U64_PER_GB = 0x8000000;
 
 #ifdef PARALLEL
-const u64 MAX_WORKERS = 8;
+#define MAX_WORKERS (8)
 #else
-const u64 MAX_WORKERS = 1;
+#define MAX_WORKERS (1)
 #endif
 const u64 MAX_DYNFUNS = 65536;
-const u64 MAX_ARITY = 16;
+#define MAX_ARITY (16)
 const u64 MEM_SPACE = U64_PER_GB; // each worker has 1 GB of the 8 GB total
 
 // Terms
@@ -1182,7 +1182,7 @@ void normal_fork(u64 tid, u64 host, u64 sidx, u64 slen);
 u64  normal_join(u64 tid);
 #endif
 
-const u64 normal_seen_mcap = 16777216; // uses 128 MB, covers heaps up to 8 GB
+#define normal_seen_mcap (16777216) // uses 128 MB, covers heaps up to 8 GB
 u64 normal_seen_data[normal_seen_mcap];
 
 void normal_init() {{
@@ -1357,7 +1357,7 @@ void ffi_normal(u8* mem_data, u32 mem_size, u32 host) {{
     workers[t].has_result = -1;
     pthread_mutex_init(&workers[t].has_result_mutex, NULL);
     pthread_cond_init(&workers[t].has_result_signal, NULL);
-    workers[t].thread = NULL;
+    // workers[t].thread = NULL;
     #endif
   }}
 


### PR DESCRIPTION
This fixes these warnings while compiling on Linux:

```
main.hovm.out.c:110:8: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
  Stk  free[MAX_ARITY];
       ^
main.hovm.out.c:129:8: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
Worker workers[MAX_WORKERS];
       ^
main.hovm.out.c:1160:5: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
u64 normal_seen_data[normal_seen_mcap];
    ^
main.hovm.out.c:1334:23: warning: incompatible pointer to integer conversion assigning to 'Thd' (aka 'unsigned long') from 'void *' [-Wint-conversion]
    workers[t].thread = NULL;
 ```